### PR TITLE
Updates wazero to its first beta

### DIFF
--- a/third_party/go.mod
+++ b/third_party/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	github.com/tango-contrib/basicauth v0.0.0-20170526072948-7fbc19aece86
-	github.com/tetratelabs/wazero v0.0.0-20220430041858-abd1c79f3335
+	github.com/tetratelabs/wazero v1.0.0-beta.1
 	github.com/traefik/yaegi v0.9.14
 	github.com/urfave/cli v1.22.5
 	github.com/v2fly/v2ray-core/v4 v4.36.2


### PR DESCRIPTION
This updates to the first beta release of [wazero](https://wazero.io): 1.0.0-beta.1

Future betas will release at the end of each month until 1.0 in February 2023.

Note: [Release notes](https://github.com/tetratelabs/wazero/releases) will be posted in the next day or two.

Meanwhile, we've also opened a [gophers slack](https://gophers.slack.com/) `#wazero` channel for support, updates and conversation! Note: You may need an [invite](https://invite.slack.golangbridge.org/) to join gophers.