### PR TITLE
Support server-sent events (SSE) on /api/agents/watch

### DIFF
--- a/pkg/hub/go.mod
+++ b/pkg/hub/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/abbot/go-http-auth v0.4.0
 	github.com/btwiuse/pretty v0.2.1
+	github.com/btwiuse/sse v0.0.1
 	github.com/btwiuse/wetty v0.0.36
 	github.com/gorilla/mux v1.8.0
 	github.com/jpillora/go-echo-server v0.5.0


### PR DESCRIPTION
After the change is landed, this endpoint will be able to serve three kinds of data fetching methods from a single endpoint:
- polling: 
```
curl http://localhost:8000/api/agents/watch
```
- server-sent events
```
curl -H "Accept: text/event-stream" -N http://localhost:8000/api/agents/watch
```
- websockets
```
websocat ws://localhost:8000/api/agents/watch
```