### PR TITLE
Rework multicall binary

### DIFF
--- a/pkg/cli/go.mod
+++ b/pkg/cli/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/alexpantyukhin/go-pattern-match v0.0.0-20200628201436-c57d5ad3f2c5
+	github.com/btwiuse/multicall v0.0.0
 	github.com/creativeprojects/go-selfupdate v0.6.1
 	k0s.io/pkg/agent v0.1.5
 	k0s.io/pkg/client v0.1.5
@@ -43,6 +44,7 @@ require (
 	github.com/btwiuse/gost v0.0.1 // indirect
 	github.com/btwiuse/k16s/v2 v2.0.0-20201224175329-3bc18834f8c1 // indirect
 	github.com/btwiuse/pretty v0.2.1 // indirect
+	github.com/btwiuse/sse v0.0.1 // indirect
 	github.com/btwiuse/wetty v0.0.36 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cheekybits/genny v1.0.0 // indirect

--- a/pkg/cli/k0s/k0s.go
+++ b/pkg/cli/k0s/k0s.go
@@ -66,17 +66,6 @@ func Run(args []string) error {
 			)
 	}
 
-	matcher = matcher.When(
-		[]interface{}{
-			"k0s",
-			match.ANY,
-		},
-		func() error {
-			// log.Println("k0s")
-			return client.Run(osargs[1:])
-		},
-	)
-
 	ok, _ := matcher.Result()
 	if !ok {
 		usage()

--- a/pkg/cli/k0s/k0s.go
+++ b/pkg/cli/k0s/k0s.go
@@ -1,6 +1,7 @@
 package k0s
 
 import (
+	"log"
 	"os"
 
 	"k0s.io/pkg/cli/agent"
@@ -14,7 +15,12 @@ import (
 	"github.com/btwiuse/multicall"
 )
 
-var cmdRun multicall.RunnerFuncMap = map[string]func([]string) error{
+func TODO([]string) error {
+	log.Println("TODO: not implemented yet")
+	return nil
+}
+
+var cmdRun multicall.RunnerFuncMap = map[string]multicall.RunnerFunc{
 	"mnt":        mnt.Run,
 	"chassis":    chassis.Run,
 	"client":     client.Run,
@@ -23,8 +29,11 @@ var cmdRun multicall.RunnerFuncMap = map[string]func([]string) error{
 	"hub2":       hub.Run2,
 	"agent":      agent.Run,
 	"upgrade":    upgrade.Run,
+	"kuber":      TODO,
+	"knot":       TODO,
+	"version":    TODO,
 }
 
 func Run(args []string) error {
-	return cmdRun.Run(os.Args)
+	return cmdRun.Run(os.Args[1:])
 }

--- a/pkg/cli/k0s/k0s.go
+++ b/pkg/cli/k0s/k0s.go
@@ -1,7 +1,7 @@
 package k0s
 
 import (
-	"log"
+	"fmt"
 	"os"
 
 	"k0s.io/pkg/cli/agent"
@@ -16,7 +16,7 @@ import (
 )
 
 func TODO([]string) error {
-	log.Println("TODO: not implemented yet")
+	fmt.Println("TODO: not implemented yet")
 	return nil
 }
 


### PR DESCRIPTION
- remove fallback to `client.Run`
- use github.com/btwiuse/multicall
- add `kuber`, `knot` subcommands
- add `version` subcommand